### PR TITLE
Fix synchronization issues (fatal error: concurrent map writes)

### DIFF
--- a/base_signal.go
+++ b/base_signal.go
@@ -1,6 +1,9 @@
 package signals
 
-import "context"
+import (
+	"context"
+	"sync"
+)
 
 // keyedListener represents a combination of a listener and an optional key used for identification.
 type keyedListener[T any] struct {
@@ -12,6 +15,7 @@ type keyedListener[T any] struct {
 // It is intended to be used as an abstract base for underlying signal mechanisms.
 //
 // Example:
+//
 //	type MyDerivedSignal[T any] struct {
 //		BaseSignal[T]
 //		// Additional fields or methods specific to MyDerivedSignal
@@ -21,6 +25,7 @@ type keyedListener[T any] struct {
 //		// Custom implementation for emitting the signal
 //	}
 type BaseSignal[T any] struct {
+	mu             sync.Mutex
 	subscribers    []keyedListener[T]
 	subscribersMap map[string]SignalListener[T]
 }
@@ -32,6 +37,7 @@ type BaseSignal[T any] struct {
 // -1 if the listener with the same key was already added to the signal.
 //
 // Example:
+//
 //	signal := signals.New[int]()
 //	count := signal.AddListener(func(ctx context.Context, payload int) {
 //		// Listener implementation
@@ -39,6 +45,9 @@ type BaseSignal[T any] struct {
 //	}, "key1")
 //	fmt.Println("Number of subscribers after adding listener:", count)
 func (s *BaseSignal[T]) AddListener(listener SignalListener[T], key ...string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if len(key) > 0 {
 		if _, ok := s.subscribersMap[key[0]]; ok {
 			return -1
@@ -62,6 +71,7 @@ func (s *BaseSignal[T]) AddListener(listener SignalListener[T], key ...string) i
 // listener was not found.
 //
 // Example:
+//
 //	signal := signals.New[int]()
 //	signal.AddListener(func(ctx context.Context, payload int) {
 //		// Listener implementation
@@ -70,6 +80,9 @@ func (s *BaseSignal[T]) AddListener(listener SignalListener[T], key ...string) i
 //	count := signal.RemoveListener("key1")
 //	fmt.Println("Number of subscribers after removing listener:", count)
 func (s *BaseSignal[T]) RemoveListener(key string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if _, ok := s.subscribersMap[key]; ok {
 		delete(s.subscribersMap, key)
 
@@ -91,6 +104,7 @@ func (s *BaseSignal[T]) RemoveListener(key string) int {
 // further signals.
 //
 // Example:
+//
 //	signal := signals.New[int]()
 //	signal.AddListener(func(ctx context.Context, payload int) {
 //		// Listener implementation
@@ -99,6 +113,9 @@ func (s *BaseSignal[T]) RemoveListener(key string) int {
 //	signal.Reset() // Removes all listeners
 //	fmt.Println("Number of subscribers after resetting:", signal.Len())
 func (s *BaseSignal[T]) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	
 	s.subscribers = make([]keyedListener[T], 0)
 	s.subscribersMap = make(map[string]SignalListener[T])
 }
@@ -108,6 +125,7 @@ func (s *BaseSignal[T]) Reset() {
 // The returned value is of type int.
 //
 // Example:
+//
 //	signal := signals.New[int]()
 //	signal.AddListener(func(ctx context.Context, payload int) {
 //		// Listener implementation
@@ -123,6 +141,7 @@ func (s *BaseSignal[T]) Len() int {
 // This can be used to check if there are any listeners before emitting a signal.
 //
 // Example:
+//
 //	signal := signals.New[int]()
 //	fmt.Println("Is signal empty?", signal.IsEmpty()) // Should print true
 //	signal.AddListener(func(ctx context.Context, payload int) {
@@ -138,6 +157,7 @@ func (s *BaseSignal[T]) IsEmpty() bool {
 // implemented by a derived type.
 //
 // Example:
+//
 //	type MyDerivedSignal[T any] struct {
 //		BaseSignal[T]
 //		// Additional fields or methods specific to MyDerivedSignal

--- a/base_signal.go
+++ b/base_signal.go
@@ -25,7 +25,7 @@ type keyedListener[T any] struct {
 //		// Custom implementation for emitting the signal
 //	}
 type BaseSignal[T any] struct {
-	mu             sync.Mutex
+	mu             sync.RWMutex
 	subscribers    []keyedListener[T]
 	subscribersMap map[string]SignalListener[T]
 }
@@ -115,7 +115,7 @@ func (s *BaseSignal[T]) RemoveListener(key string) int {
 func (s *BaseSignal[T]) Reset() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	
+
 	s.subscribers = make([]keyedListener[T], 0)
 	s.subscribersMap = make(map[string]SignalListener[T])
 }

--- a/signals_async.go
+++ b/signals_async.go
@@ -37,8 +37,7 @@ type AsyncSignal[T any] struct {
 //
 //	signal.Emit(context.Background(), "Hello, world!")
 func (s *AsyncSignal[T]) Emit(ctx context.Context, payload T) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
 
 	var wg sync.WaitGroup
 
@@ -49,6 +48,7 @@ func (s *AsyncSignal[T]) Emit(ctx context.Context, payload T) {
 			listener(ctx, payload)
 		}(sub.listener)
 	}
+	s.mu.RUnlock()
 
 	wg.Wait()
 }

--- a/signals_async.go
+++ b/signals_async.go
@@ -14,8 +14,6 @@ import (
 // in a separate goroutine.
 type AsyncSignal[T any] struct {
 	BaseSignal[T]
-
-	mu sync.Mutex
 }
 
 // Emit notifies all subscribers of the signal and passes the payload in a

--- a/signals_sync.go
+++ b/signals_sync.go
@@ -23,6 +23,7 @@ type SyncSignal[T any] struct {
 // called synchronously, one after the other.
 //
 // Example:
+//
 //	signal := signals.NewSync[string]()
 //	signal.AddListener(func(ctx context.Context, payload string) {
 //		// Listener implementation
@@ -31,6 +32,8 @@ type SyncSignal[T any] struct {
 //
 //	signal.Emit(context.Background(), "Hello, world!")
 func (s *SyncSignal[T]) Emit(ctx context.Context, payload T) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	for _, sub := range s.subscribers {
 		sub.listener(ctx, payload)
 	}

--- a/signals_sync.go
+++ b/signals_sync.go
@@ -32,8 +32,8 @@ type SyncSignal[T any] struct {
 //
 //	signal.Emit(context.Background(), "Hello, world!")
 func (s *SyncSignal[T]) Emit(ctx context.Context, payload T) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	for _, sub := range s.subscribers {
 		sub.listener(ctx, payload)
 	}


### PR DESCRIPTION
Hello and thank you for maintaining this library.


It's possible to trigger concurrent map writes or concurrent map read and write when calling
`AddListener` and `RemoveListener` from multiple goroutines. I used sync.Mutex on all functions that use `subscribersMap`.

I also use mutextes on Emit since removing element from `s.subscribers` while for loop is running in another goroutine could cause problems.

I have tested and this fixes my problem.

Have a great day!